### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,21 +6,14 @@
             "runner": "@nrwl/nx-cloud",
             "options": {
                 "cacheableOperations": ["build", "lint", "test", "e2e"],
-                "accessToken": "NmZiYTA5YzMtNjEyZS00MmJlLTk5M2UtMGI3NDJmMTNkNjQyfHJlYWQtd3JpdGU="
+                "accessToken": "ZjQxOGVhNzYtYjU0ZS00MjM1LThiZjctMDRjNTY2N2Q3ZWYxfHJlYWQtd3JpdGU="
             }
         }
     },
     "targetDefaults": {
-        "build": {
-            "dependsOn": ["^build"],
-            "inputs": ["production", "^production"]
-        },
-        "lint": {
-            "inputs": ["default", "{workspaceRoot}/.eslintrc.json"]
-        },
-        "test": {
-            "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
-        }
+        "build": { "dependsOn": ["^build"], "inputs": ["production", "^production"] },
+        "lint": { "inputs": ["default", "{workspaceRoot}/.eslintrc.json"] },
+        "test": { "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"] }
     },
     "namedInputs": {
         "default": ["{projectRoot}/**/*", "sharedGlobals"],
@@ -33,9 +26,6 @@
         ],
         "sharedGlobals": []
     },
-    "workspaceLayout": {
-        "appsDir": "packages",
-        "libsDir": "packages"
-    },
+    "workspaceLayout": { "appsDir": "packages", "libsDir": "packages" },
     "defaultProject": "swaps-keepers"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/66a13319e2031119c3cd3d8d/workspaces/66a13386ff44900482cc4756

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.